### PR TITLE
version variable name adjustment

### DIFF
--- a/blueprints/getting-started/main.tf
+++ b/blueprints/getting-started/main.tf
@@ -110,7 +110,7 @@ module "aws_eks_accelerator_for_terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  kubernetes_version = local.kubernetes_version
+  cluster_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS
   managed_node_groups = {


### PR DESCRIPTION
While testing the code only works if `cluster_version` is set not `kubernetes_version` (adjusted accordingly.